### PR TITLE
Replace deprecated PhpClass#getOwnFieldMap with PhpClass#getOwnFields

### DIFF
--- a/src/main/java/com/oroplatform/idea/oroplatform/intellij/indexes/RouteFileBasedIndex.java
+++ b/src/main/java/com/oroplatform/idea/oroplatform/intellij/indexes/RouteFileBasedIndex.java
@@ -71,9 +71,10 @@ public class RouteFileBasedIndex extends FileBasedIndexExtension<String, Route> 
                         final PhpClass phpClass = (PhpClass) element;
 
                         //for symfony <2.8
-                        final Collection<Field> fields = phpClass.getOwnFieldMap().get("declaredRoutes");
-                        for (Field field : fields) {
-                            indexRoutes(index, field.getDefaultValue());
+                        for (Field field : phpClass.getOwnFields()) {
+                            if (field.getName().equals("declaredRoutes")) {
+                                indexRoutes(index, field.getDefaultValue());
+                            }
                         }
 
                         //for symfony >=2.8


### PR DESCRIPTION
Hello!

In the nearest future we're plan to deprecate and remove `PhpClass#getOwnFieldMap` method from API since it's exposing the inner structure of the `PhpClass` implementation and prevents us from changing it. 

Depending on the actual logic of the code `PhpClass#findOwnFieldByName` can be more suitable here (and a bit faster), but in this PR I provided only the change which completely matches the previous behaviour.

Based on our research your plugin is the only external client of this method. Won't it make you difficult to review the changes, and if they are OK, publish new version of the plugin with them? This will help us to improve PhpStorm codebase in the future.