### PR TITLE
OPP-65: IllegalArgumentException in Twig templates used by layouts in PHPStorm 2020.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'com.oroplatform'
-version '1.0.18'
+version '1.0.19'
 
 apply plugin: 'org.jetbrains.intellij'
 apply plugin: 'java'

--- a/src/main/java/com/oroplatform/idea/oroplatform/Icons.java
+++ b/src/main/java/com/oroplatform/idea/oroplatform/Icons.java
@@ -7,10 +7,9 @@ import com.jetbrains.php.PhpIcons;
 import javax.swing.*;
 
 public class Icons {
-    public static final Icon DOCTRINE = IconLoader.findIcon("icons/doctrine.png");
-    public static final Icon TWIG = IconLoader.findIcon("icons/twig.png");
-    public static final Icon ROUTE = IconLoader.findIcon("icons/route.png");
-    public static final Icon ORO = IconLoader.findIcon("icons/oro.png");
+    public static final Icon DOCTRINE = IconLoader.getIcon("icons/doctrine.png");
+    public static final Icon ROUTE = IconLoader.getIcon("icons/route.png");
+    public static final Icon ORO = IconLoader.getIcon("icons/oro.png");
     public static final Icon PUBLIC_METHOD;
 
     static {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -10,6 +10,11 @@ Plugin for the PHPStorm that will help to increase the development speed on the 
     ]]></description>
 
     <change-notes><![CDATA[
+<h2>1.0.19</h2>
+<ul>
+  <li>[#17] Fixed IllegalArgumentException in Twig templates used by layouts in PHPStorm 2020.3</li>
+</ul>
+
 <h2>1.0.18</h2>
 <ul>
   <li>[#15] extended_entity_name and table options for datagrids provide incorrect suggestions</li>


### PR DESCRIPTION
Fixes #16 